### PR TITLE
Add Respawn Button When Lives Remain

### DIFF
--- a/src/main/java/fr/factionbedrock/notsohardcore/events/NSHPlayerEvents.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/events/NSHPlayerEvents.java
@@ -7,6 +7,7 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.world.GameMode;
 
 public class NSHPlayerEvents
 {
@@ -21,6 +22,13 @@ public class NSHPlayerEvents
         ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) ->
         {
             ServerPlayNetworking.send(newPlayer, new NSHS2CSynchData("sync_nsh_data", NotSoHardcore.MAX_LIVES, NotSoHardcore.TIME_TO_REGAIN_LIFE, NotSoHardcore.CREATIVE_RESETS_LIFE_COUNT, newPlayer.getDataTracker().get(NSHTrackedData.LIVES), newPlayer.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER)));
+
+            // Force Survival on the next tick if the player has lives (avoids ordering with hardcore spectator enforcement)
+            int lives = newPlayer.getDataTracker().get(NSHTrackedData.LIVES);
+            if (lives > 0 && !newPlayer.isCreative())
+            {
+                newPlayer.server.execute(() -> newPlayer.changeGameMode(GameMode.SURVIVAL));
+            }
         });
     }
 }

--- a/src/main/java/fr/factionbedrock/notsohardcore/mixin/DeathScreenMixin.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/mixin/DeathScreenMixin.java
@@ -1,0 +1,46 @@
+package fr.factionbedrock.notsohardcore.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import fr.factionbedrock.notsohardcore.registry.NSHTrackedData;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.DeathScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+
+@Mixin(DeathScreen.class)
+public abstract class DeathScreenMixin {
+
+    @Inject(method = "init", at = @At("TAIL"))
+
+    private void nsh$addRespawnButton(CallbackInfo ci) {
+        MinecraftClient mc = MinecraftClient.getInstance();
+        if (mc == null || mc.player == null) return;
+
+        int lives = mc.player.getDataTracker().get(NSHTrackedData.LIVES);
+
+
+        boolean hardcore = mc.world.getLevelProperties().isHardcore();
+
+        // Only add in hardcore, and only if the player still hass lives
+
+        if (hardcore && lives > 0)
+        {
+            int x = mc.getWindow().getScaledWidth() / 2 - 100;
+            int y = mc.getWindow().getScaledHeight() / 4 + 120;
+
+            ButtonWidget respawn = ButtonWidget.builder(
+                Text.translatable("deathScreen.respawn"),
+                btn -> mc.player.requestRespawn()
+            ).dimensions(x, y, 200, 20).build();
+
+            ((Screen)(Object)this).addDrawableChild(respawn);
+        }
+
+        
+    }
+}

--- a/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerDeathMixin.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerDeathMixin.java
@@ -38,4 +38,5 @@ public class PlayerDeathMixin
         long live_regain_timer = oldPlayer.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER);
         newPlayer.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_TIME_MARKER, live_regain_timer);
     }
+
 }

--- a/src/main/resources/notsohardcore.mixins.json
+++ b/src/main/resources/notsohardcore.mixins.json
@@ -1,14 +1,17 @@
 {
-	"required": true,
-	"package": "fr.factionbedrock.notsohardcore.mixin",
-	"compatibilityLevel": "JAVA_21",
-	"mixins": [
-		"PlayerDataTrackerMixin",
-		"PlayerNbtMixin",
-		"PlayerTickMixin",
-		"PlayerDeathMixin"
-	],
-	"injectors": {
-		"defaultRequire": 1
-	}
+  "required": true,
+  "package": "fr.factionbedrock.notsohardcore.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "PlayerDataTrackerMixin",
+    "PlayerNbtMixin",
+    "PlayerTickMixin",
+    "PlayerDeathMixin"
+  ],
+  "client": [
+    "DeathScreenMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
 }


### PR DESCRIPTION
This PR fixes the issue where the respawn option would not appear even if the player still had lives left.

- Added a respawn button so players can respawn properly.
- Tested in singleplayer worlds (works as expected).
- Not tested on servers, so behavior there may differ.

This change solves my immediate needs in singleplayer, but I hope it also helps others who encounter the same problem. 