### PR TITLE
Fix Respawn Option + Add Configurable Features

### DIFF
--- a/src/main/java/fr/factionbedrock/notsohardcore/NotSoHardcore.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/NotSoHardcore.java
@@ -1,6 +1,7 @@
 package fr.factionbedrock.notsohardcore;
 
 import fr.factionbedrock.notsohardcore.client.packet.NSHClientNetworking;
+import fr.factionbedrock.notsohardcore.commands.NSHCommands;
 import fr.factionbedrock.notsohardcore.client.registry.NSHKeyBinds;
 import fr.factionbedrock.notsohardcore.config.*;
 import fr.factionbedrock.notsohardcore.events.NSHPlayerEvents;
@@ -16,29 +17,45 @@ import org.slf4j.LoggerFactory;
 
 public class NotSoHardcore implements ModInitializer, ClientModInitializer
 {
-	public static final String MOD_ID = "notsohardcore";
-	
-	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+    public static final String MOD_ID = "notsohardcore";
+    
+    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
-	public static NSHConfig CONFIG;
-	public static int MAX_LIVES;
-	public static int TIME_TO_REGAIN_LIFE;
-	public static Boolean CREATIVE_RESETS_LIFE_COUNT;
+    public static NSHConfig CONFIG;
+    public static int MAX_LIVES;
+    public static int TIME_TO_REGAIN_LIFE;
+    public static Boolean CREATIVE_RESETS_LIFE_COUNT;
+    // New realtime regain configuration (server-synced)
+    public static Boolean USE_REALTIME_REGAIN;
+    public static int TIME_TO_REGAIN_LIFE_SECONDS;
 
-	@Override public void onInitialize()
-	{
-		CONFIG = NSHConfigLoader.loadConfig();
-		MAX_LIVES = Math.max(CONFIG.maxLives, 1);
-		TIME_TO_REGAIN_LIFE = CONFIG.timeToRegainLife >= 0 ? CONFIG.timeToRegainLife : Integer.MAX_VALUE;
-		CREATIVE_RESETS_LIFE_COUNT = CONFIG.creativeResetsLifeCount;
-		ServerLoadedConfig.storeServerParams(MAX_LIVES, TIME_TO_REGAIN_LIFE, CREATIVE_RESETS_LIFE_COUNT);
+    @Override public void onInitialize()
+    {
+        CONFIG = NSHConfigLoader.loadConfig();
+        MAX_LIVES = Math.max(CONFIG.maxLives, 1);
+        TIME_TO_REGAIN_LIFE = CONFIG.timeToRegainLife >= 0 ? CONFIG.timeToRegainLife : Integer.MAX_VALUE;
+        CREATIVE_RESETS_LIFE_COUNT = CONFIG.creativeResetsLifeCount;
+        // Realtime regain params
+        USE_REALTIME_REGAIN = CONFIG.useRealtimeRegain;
+        TIME_TO_REGAIN_LIFE_SECONDS = CONFIG.timeToRegainLifeSeconds > 0 ? CONFIG.timeToRegainLifeSeconds : Integer.MAX_VALUE;
+
+        // Publish server-side effective params (including realtime mode)
+        ServerLoadedConfig.storeServerParams(
+                MAX_LIVES,
+                TIME_TO_REGAIN_LIFE,
+                CREATIVE_RESETS_LIFE_COUNT,
+                USE_REALTIME_REGAIN,
+                TIME_TO_REGAIN_LIFE_SECONDS);
 
 		NSHItems.load();
 		NSHTrackedData.load();
-		NSHNetworking.registerData();
-		NSHNetworking.registerServerReceiver();
-		NSHPlayerEvents.registerPlayerEvents();
-	}
+        NSHNetworking.registerData();
+        NSHNetworking.registerServerReceiver();
+        NSHPlayerEvents.registerPlayerEvents();
+
+        // Register in-game commands (singleplayer/integrated server compatible)
+        NSHCommands.register();
+    }
 
 	@Override public void onInitializeClient()
 	{

--- a/src/main/java/fr/factionbedrock/notsohardcore/client/packet/NSHClientNetworking.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/client/packet/NSHClientNetworking.java
@@ -17,7 +17,14 @@ public class NSHClientNetworking
                 MinecraftClient client = MinecraftClient.getInstance();
                 client.player.getDataTracker().set(NSHTrackedData.LIVES, payload.lives());
                 client.player.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_TIME_MARKER, payload.live_regain_time_marker());
-                ServerLoadedConfig.storeServerParams(payload.max_lives(), payload.time_to_regain_life(), payload.creative_resets_life_count());
+                client.player.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER, payload.live_regain_realtime_time_marker());
+                ServerLoadedConfig.storeServerParams(
+                        payload.max_lives(),
+                        payload.time_to_regain_life(),
+                        payload.creative_resets_life_count(),
+                        payload.use_realtime(),
+                        payload.time_to_regain_life_seconds()
+                );
             }
         });
     }

--- a/src/main/java/fr/factionbedrock/notsohardcore/commands/NSHCommands.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/commands/NSHCommands.java
@@ -1,0 +1,136 @@
+package fr.factionbedrock.notsohardcore.commands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import fr.factionbedrock.notsohardcore.NotSoHardcore;
+import fr.factionbedrock.notsohardcore.config.NSHConfigLoader;
+import fr.factionbedrock.notsohardcore.config.ServerLoadedConfig;
+import fr.factionbedrock.notsohardcore.packet.NSHS2CSynchData;
+import fr.factionbedrock.notsohardcore.registry.NSHTrackedData;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+public final class NSHCommands {
+    private NSHCommands() {}
+
+    public static void register() {
+        CommandRegistrationCallback.EVENT.register(NSHCommands::registerImpl);
+    }
+
+    private static void registerImpl(CommandDispatcher<ServerCommandSource> dispatcher, net.minecraft.registry.RegistryWrapper.WrapperLookup registryAccess, CommandManager.RegistrationEnvironment env) {
+        dispatcher.register(
+                literal("nsh").requires(src -> src.hasPermissionLevel(2))
+                        .then(literal("realtime")
+                                .then(argument("value", BoolArgumentType.bool())
+                                        .executes(ctx -> {
+                                            boolean value = BoolArgumentType.getBool(ctx, "value");
+                                            NotSoHardcore.CONFIG.useRealtimeRegain = value;
+                                            applyAndSave(ctx.getSource());
+                                            ctx.getSource().sendFeedback(() -> Text.literal("useRealtimeRegain = " + value), true);
+                                            return 1;
+                                        })
+                                )
+                        )
+                        .then(literal("maxLives")
+                                .then(argument("value", IntegerArgumentType.integer(1, 1000))
+                                        .executes(ctx -> {
+                                            int value = IntegerArgumentType.getInteger(ctx, "value");
+                                            NotSoHardcore.CONFIG.maxLives = value;
+                                            applyAndSave(ctx.getSource());
+                                            clampAllPlayersLives(ctx.getSource(), value);
+                                            ctx.getSource().sendFeedback(() -> Text.literal("maxLives = " + value), true);
+                                            return 1;
+                                        })
+                                )
+                        )
+                        .then(literal("cooldown")
+                                .then(literal("seconds")
+                                        .then(argument("value", IntegerArgumentType.integer(1))
+                                                .executes(ctx -> {
+                                                    int value = IntegerArgumentType.getInteger(ctx, "value");
+                                                    NotSoHardcore.CONFIG.timeToRegainLifeSeconds = value;
+                                                    applyAndSave(ctx.getSource());
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("timeToRegainLifeSeconds = " + value), true);
+                                                    return 1;
+                                                })
+                                        )
+                                )
+                                .then(literal("ticks")
+                                        .then(argument("value", IntegerArgumentType.integer(1))
+                                                .executes(ctx -> {
+                                                    int value = IntegerArgumentType.getInteger(ctx, "value");
+                                                    NotSoHardcore.CONFIG.timeToRegainLife = value;
+                                                    applyAndSave(ctx.getSource());
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("timeToRegainLife (ticks) = " + value), true);
+                                                    return 1;
+                                                })
+                                        )
+                                )
+                        )
+                        .then(literal("show").executes(ctx -> {
+                            ctx.getSource().sendFeedback(() -> Text.literal("maxLives = " + NotSoHardcore.MAX_LIVES), false);
+                            ctx.getSource().sendFeedback(() -> Text.literal("useRealtimeRegain = " + ServerLoadedConfig.USE_REALTIME_REGAIN), false);
+                            ctx.getSource().sendFeedback(() -> Text.literal("timeToRegainLife (ticks) = " + ServerLoadedConfig.TIME_TO_REGAIN_LIFE), false);
+                            ctx.getSource().sendFeedback(() -> Text.literal("timeToRegainLifeSeconds = " + ServerLoadedConfig.TIME_TO_REGAIN_LIFE_SECONDS), false);
+                            return 1;
+                        }))
+        );
+    }
+
+    private static void applyAndSave(ServerCommandSource src) {
+        // Recompute effective values from CONFIG
+        NotSoHardcore.MAX_LIVES = Math.max(NotSoHardcore.CONFIG.maxLives, 1);
+        NotSoHardcore.TIME_TO_REGAIN_LIFE = NotSoHardcore.CONFIG.timeToRegainLife >= 0 ? NotSoHardcore.CONFIG.timeToRegainLife : Integer.MAX_VALUE;
+        NotSoHardcore.CREATIVE_RESETS_LIFE_COUNT = NotSoHardcore.CONFIG.creativeResetsLifeCount;
+        NotSoHardcore.USE_REALTIME_REGAIN = NotSoHardcore.CONFIG.useRealtimeRegain;
+        NotSoHardcore.TIME_TO_REGAIN_LIFE_SECONDS = NotSoHardcore.CONFIG.timeToRegainLifeSeconds > 0 ? NotSoHardcore.CONFIG.timeToRegainLifeSeconds : Integer.MAX_VALUE;
+
+        // Persist to disk
+        NSHConfigLoader.saveConfig(NotSoHardcore.CONFIG);
+
+        // Update server-side store
+        ServerLoadedConfig.storeServerParams(
+                NotSoHardcore.MAX_LIVES,
+                NotSoHardcore.TIME_TO_REGAIN_LIFE,
+                NotSoHardcore.CREATIVE_RESETS_LIFE_COUNT,
+                NotSoHardcore.USE_REALTIME_REGAIN,
+                NotSoHardcore.TIME_TO_REGAIN_LIFE_SECONDS
+        );
+
+        // Broadcast new values to players
+        if (src.getServer() != null) {
+            for (ServerPlayerEntity p : src.getServer().getPlayerManager().getPlayerList()) {
+                ServerPlayNetworking.send(p, new NSHS2CSynchData(
+                        "sync_nsh_data",
+                        NotSoHardcore.MAX_LIVES,
+                        NotSoHardcore.TIME_TO_REGAIN_LIFE,
+                        NotSoHardcore.CREATIVE_RESETS_LIFE_COUNT,
+                        p.getDataTracker().get(NSHTrackedData.LIVES),
+                        p.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER),
+                        NotSoHardcore.USE_REALTIME_REGAIN,
+                        NotSoHardcore.TIME_TO_REGAIN_LIFE_SECONDS,
+                        p.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER)
+                ));
+            }
+        }
+    }
+
+    private static void clampAllPlayersLives(ServerCommandSource src, int maxLives) {
+        if (src.getServer() == null) return;
+        for (ServerPlayerEntity p : src.getServer().getPlayerManager().getPlayerList()) {
+            int lives = p.getDataTracker().get(NSHTrackedData.LIVES);
+            if (lives > maxLives) {
+                p.getDataTracker().set(NSHTrackedData.LIVES, maxLives);
+            }
+        }
+    }
+}
+

--- a/src/main/java/fr/factionbedrock/notsohardcore/config/NSHConfig.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/config/NSHConfig.java
@@ -5,4 +5,8 @@ public class NSHConfig
     public int maxLives = 3;
     public int timeToRegainLife = 72000;
     public boolean creativeResetsLifeCount = false;
+    // Optional realtime-based regain (off by default). When enabled, lives
+    // regain based on wall-clock seconds instead of in-game ticks.
+    public boolean useRealtimeRegain = false;
+    public int timeToRegainLifeSeconds = 3600; // 1 hour
 }

--- a/src/main/java/fr/factionbedrock/notsohardcore/config/ServerLoadedConfig.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/config/ServerLoadedConfig.java
@@ -6,11 +6,24 @@ public class ServerLoadedConfig
     public static int MAX_LIVES;
     public static int TIME_TO_REGAIN_LIFE;
     public static Boolean CREATIVE_RESETS_LIFE_COUNT;
+    // Realtime regain configuration (server authoritative)
+    public static Boolean USE_REALTIME_REGAIN;
+    public static int TIME_TO_REGAIN_LIFE_SECONDS;
 
     public static void storeServerParams(int maxLives, int timeToRegainLife, boolean creativeResetsLifeCount)
     {
         MAX_LIVES = maxLives;
         TIME_TO_REGAIN_LIFE = timeToRegainLife;
         CREATIVE_RESETS_LIFE_COUNT = creativeResetsLifeCount;
+    }
+
+    public static void storeServerParams(int maxLives, int timeToRegainLife, boolean creativeResetsLifeCount,
+                                         boolean useRealtimeRegain, int timeToRegainLifeSeconds)
+    {
+        MAX_LIVES = maxLives;
+        TIME_TO_REGAIN_LIFE = timeToRegainLife;
+        CREATIVE_RESETS_LIFE_COUNT = creativeResetsLifeCount;
+        USE_REALTIME_REGAIN = useRealtimeRegain;
+        TIME_TO_REGAIN_LIFE_SECONDS = timeToRegainLifeSeconds;
     }
 }

--- a/src/main/java/fr/factionbedrock/notsohardcore/events/NSHPlayerEvents.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/events/NSHPlayerEvents.java
@@ -7,6 +7,7 @@ import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.world.GameMode;
 
 public class NSHPlayerEvents
 {
@@ -21,6 +22,13 @@ public class NSHPlayerEvents
         ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) ->
         {
             ServerPlayNetworking.send(newPlayer, new NSHS2CSynchData("sync_nsh_data", NotSoHardcore.MAX_LIVES, NotSoHardcore.TIME_TO_REGAIN_LIFE, NotSoHardcore.CREATIVE_RESETS_LIFE_COUNT, newPlayer.getDataTracker().get(NSHTrackedData.LIVES), newPlayer.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER)));
+
+            // Force Survival on the next tick if the player has lives (avoids ordering with hardcore spectator enforcement)
+            int lives = newPlayer.getDataTracker().get(NSHTrackedData.LIVES);
+            if (lives > 0 && !newPlayer.isCreative())
+            {
+                newPlayer.server.execute(() -> newPlayer.changeGameMode(GameMode.SURVIVAL));
+            }
         });
     }
 }

--- a/src/main/java/fr/factionbedrock/notsohardcore/events/NSHPlayerEvents.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/events/NSHPlayerEvents.java
@@ -16,12 +16,32 @@ public class NSHPlayerEvents
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) ->
         {
             ServerPlayerEntity player = handler.getPlayer();
-            ServerPlayNetworking.send(player, new NSHS2CSynchData("sync_nsh_data", NotSoHardcore.MAX_LIVES, NotSoHardcore.TIME_TO_REGAIN_LIFE, NotSoHardcore.CREATIVE_RESETS_LIFE_COUNT, player.getDataTracker().get(NSHTrackedData.LIVES), player.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER)));
+            ServerPlayNetworking.send(player, new NSHS2CSynchData(
+                    "sync_nsh_data",
+                    NotSoHardcore.MAX_LIVES,
+                    NotSoHardcore.TIME_TO_REGAIN_LIFE,
+                    NotSoHardcore.CREATIVE_RESETS_LIFE_COUNT,
+                    player.getDataTracker().get(NSHTrackedData.LIVES),
+                    player.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER),
+                    NotSoHardcore.USE_REALTIME_REGAIN,
+                    NotSoHardcore.TIME_TO_REGAIN_LIFE_SECONDS,
+                    player.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER)
+            ));
         });
 
         ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) ->
         {
-            ServerPlayNetworking.send(newPlayer, new NSHS2CSynchData("sync_nsh_data", NotSoHardcore.MAX_LIVES, NotSoHardcore.TIME_TO_REGAIN_LIFE, NotSoHardcore.CREATIVE_RESETS_LIFE_COUNT, newPlayer.getDataTracker().get(NSHTrackedData.LIVES), newPlayer.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER)));
+            ServerPlayNetworking.send(newPlayer, new NSHS2CSynchData(
+                    "sync_nsh_data",
+                    NotSoHardcore.MAX_LIVES,
+                    NotSoHardcore.TIME_TO_REGAIN_LIFE,
+                    NotSoHardcore.CREATIVE_RESETS_LIFE_COUNT,
+                    newPlayer.getDataTracker().get(NSHTrackedData.LIVES),
+                    newPlayer.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER),
+                    NotSoHardcore.USE_REALTIME_REGAIN,
+                    NotSoHardcore.TIME_TO_REGAIN_LIFE_SECONDS,
+                    newPlayer.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER)
+            ));
 
             // Force Survival on the next tick if the player has lives (avoids ordering with hardcore spectator enforcement)
             int lives = newPlayer.getDataTracker().get(NSHTrackedData.LIVES);

--- a/src/main/java/fr/factionbedrock/notsohardcore/mixin/DeathScreenMixin.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/mixin/DeathScreenMixin.java
@@ -1,0 +1,46 @@
+package fr.factionbedrock.notsohardcore.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import fr.factionbedrock.notsohardcore.registry.NSHTrackedData;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.DeathScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+
+@Mixin(DeathScreen.class)
+public abstract class DeathScreenMixin {
+
+    @Inject(method = "init", at = @At("TAIL"))
+
+    private void nsh$addRespawnButton(CallbackInfo ci) {
+        MinecraftClient mc = MinecraftClient.getInstance();
+        if (mc == null || mc.player == null) return;
+
+        int lives = mc.player.getDataTracker().get(NSHTrackedData.LIVES);
+
+
+        boolean hardcore = mc.world.getLevelProperties().isHardcore();
+
+        // Only add in hardcore, and only if the player still hass lives
+
+        if (hardcore && lives > 0)
+        {
+            int x = mc.getWindow().getScaledWidth() / 2 - 100;
+            int y = mc.getWindow().getScaledHeight() / 4 + 120;
+
+            ButtonWidget respawn = ButtonWidget.builder(
+                Text.translatable("deathScreen.respawn"),
+                btn -> mc.player.requestRespawn()
+            ).dimensions(x, y, 200, 20).build();
+
+            ((Screen)(Object)this).addDrawableChild(respawn);
+        }
+
+        
+    }
+}

--- a/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerDataTrackerMixin.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerDataTrackerMixin.java
@@ -17,5 +17,6 @@ public class PlayerDataTrackerMixin
 	{
 		builder.add(NSHTrackedData.LIVES, NotSoHardcore.MAX_LIVES);
 		builder.add(NSHTrackedData.LIFE_REGAIN_TIME_MARKER, (long)0);
+		builder.add(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER, 0L);
 	}
 }

--- a/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerDeathMixin.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerDeathMixin.java
@@ -38,4 +38,5 @@ public class PlayerDeathMixin
         long live_regain_timer = oldPlayer.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER);
         newPlayer.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_TIME_MARKER, live_regain_timer);
     }
+
 }

--- a/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerDeathMixin.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerDeathMixin.java
@@ -22,7 +22,13 @@ public class PlayerDeathMixin
         {
             if (previousLives == ServerLoadedConfig.MAX_LIVES)
             {
-                player.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_TIME_MARKER, player.getServerWorld().getTime());
+                if (ServerLoadedConfig.USE_REALTIME_REGAIN)
+                {
+                    player.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER, System.currentTimeMillis());
+                }else
+                {
+                    player.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_TIME_MARKER, player.getServerWorld().getTime());
+                }
             }
             player.getDataTracker().set(NSHTrackedData.LIVES, previousLives - 1);
         }
@@ -32,6 +38,9 @@ public class PlayerDeathMixin
     private void applyOnCopyFrom(ServerPlayerEntity oldPlayer, boolean alive, CallbackInfo info)
     {
         ServerPlayerEntity newPlayer = (ServerPlayerEntity) (Object) this;
+
+        long realtimeMarker = oldPlayer.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER);
+        newPlayer.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER, realtimeMarker);
 
         int lives = oldPlayer.getDataTracker().get(NSHTrackedData.LIVES);
         newPlayer.getDataTracker().set(NSHTrackedData.LIVES, lives);

--- a/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerNbtMixin.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerNbtMixin.java
@@ -15,6 +15,7 @@ public class PlayerNbtMixin
 {
     private static String lives = "lives";
     private static String life_regain_time_marker = "life_regain_time_marker";
+    private static String life_regain_realtime_time_marker = "life_regain_realtime_time_marker";
 
     @Inject(at = @At("RETURN"), method = "readCustomDataFromNbt")
     private void read(NbtCompound nbt, CallbackInfo info)
@@ -22,6 +23,7 @@ public class PlayerNbtMixin
         PlayerEntity player = (PlayerEntity) (Object) this;
         player.getDataTracker().set(NSHTrackedData.LIVES, nbt.getInt(lives, ServerLoadedConfig.MAX_LIVES));
         player.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_TIME_MARKER, nbt.getLong(life_regain_time_marker, 0));
+        player.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER, nbt.getLong(life_regain_realtime_time_marker, 0));
     }
 
     @Inject(at = @At("RETURN"), method = "writeCustomDataToNbt")
@@ -30,5 +32,6 @@ public class PlayerNbtMixin
         PlayerEntity player = (PlayerEntity) (Object) this;
         nbt.putInt(lives, player.getDataTracker().get(NSHTrackedData.LIVES));
         nbt.putLong(life_regain_time_marker, player.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_TIME_MARKER));
+        nbt.putLong(life_regain_realtime_time_marker, player.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER));
     }
 }

--- a/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerTickMixin.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/mixin/PlayerTickMixin.java
@@ -41,7 +41,10 @@ public abstract class PlayerTickMixin
         }
         else if (lives != ServerLoadedConfig.MAX_LIVES)
         {
-            long currentTime = player.getServerWorld().getTime();
+            if (!ServerLoadedConfig.USE_REALTIME_REGAIN)
+            {
+                // Tick time tracking
+                long currentTime = player.getServerWorld().getTime();
             if (currentTime - liveRegainTimeMarker < ServerLoadedConfig.TIME_TO_REGAIN_LIFE)
             {
                 if (lives == 0 && !player.isSpectator() && !player.isCreative())
@@ -64,6 +67,42 @@ public abstract class PlayerTickMixin
                 player.getDataTracker().set(NSHTrackedData.LIVES, Math.min(ServerLoadedConfig.MAX_LIVES, lives + livePlayerCanRegain));
                 player.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_TIME_MARKER, currentTime);
             }
+            }else
+            {
+                //Realtime mode
+                long marker = player.getDataTracker().get(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER); 
+
+                long now = System.currentTimeMillis();
+                long periodMillis = (long) ServerLoadedConfig.TIME_TO_REGAIN_LIFE_SECONDS * 1000L;
+
+                if (now - marker < periodMillis)
+                {
+                    if (lives == 0 && !player.isSpectator() && !player.isCreative())
+                    {
+                        player.changeGameMode(GameMode.SPECTATOR);
+                    }
+                } else {
+                    int canRegain = (int) ((now -marker) / periodMillis);
+
+                    if (lives == 0)
+                    {
+                        // tp to spawn resued code
+                        // TODO: defined to as a reusable helper method
+                        ServerPlayerEntity.Respawn respawn = player.getRespawn();
+                        ServerWorld serverWorld = respawn != null ? player.server.getWorld(ServerPlayerEntity.Respawn.getDimension(respawn)) : player.getServerWorld();
+                        BlockPos spawnPos = respawn != null ? respawn.pos() : serverWorld.getSpawnPos();
+
+                        player.teleport(serverWorld, spawnPos.getX(), spawnPos.getY(), spawnPos.getZ(), Set.of(), player.getYaw(), player.getPitch(), true);
+                        player.changeGameMode(GameMode.SURVIVAL);
+                    }
+
+                    player.getDataTracker().set(NSHTrackedData.LIVES, Math.min(ServerLoadedConfig.MAX_LIVES, lives + canRegain));
+                    long remainder = (now - marker) % periodMillis;
+
+                    player.getDataTracker().set(NSHTrackedData.LIFE_REGAIN_REALTIME_MARKER, now -remainder);
+                }
+            }
+            
         }
     }
 }

--- a/src/main/java/fr/factionbedrock/notsohardcore/packet/NSHS2CSynchData.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/packet/NSHS2CSynchData.java
@@ -5,8 +5,19 @@ import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.network.packet.CustomPayload.Id;
 
-public record NSHS2CSynchData(String name, int max_lives, int time_to_regain_life, boolean creative_resets_life_count, int lives, long live_regain_time_marker) implements CustomPayload
+public record NSHS2CSynchData(
+        String name,
+        int max_lives,
+        int time_to_regain_life,
+        boolean creative_resets_life_count,
+        int lives,
+        long live_regain_time_marker,
+        boolean use_realtime,
+        int time_to_regain_life_seconds,
+        long live_regain_realtime_time_marker
+) implements CustomPayload
 {
     public static final Id<NSHS2CSynchData> ID = new Id<>(NotSoHardcore.id("s2c_sync_data"));
 
@@ -17,7 +28,11 @@ public record NSHS2CSynchData(String name, int max_lives, int time_to_regain_lif
             PacketCodecs.BOOLEAN, NSHS2CSynchData::creative_resets_life_count,
             PacketCodecs.VAR_INT, NSHS2CSynchData::lives,
             PacketCodecs.VAR_LONG, NSHS2CSynchData::live_regain_time_marker,
-            NSHS2CSynchData::new);
+            PacketCodecs.BOOLEAN, NSHS2CSynchData::use_realtime,
+            PacketCodecs.VAR_INT, NSHS2CSynchData::time_to_regain_life_seconds,
+            PacketCodecs.VAR_LONG, NSHS2CSynchData::live_regain_realtime_time_marker,
+            NSHS2CSynchData::new
+    );
 
     @Override public Id<? extends CustomPayload> getId() {return ID;}
 }

--- a/src/main/java/fr/factionbedrock/notsohardcore/registry/NSHTrackedData.java
+++ b/src/main/java/fr/factionbedrock/notsohardcore/registry/NSHTrackedData.java
@@ -9,6 +9,7 @@ public class NSHTrackedData
 {
     public static final TrackedData<Integer> LIVES = DataTracker.registerData(PlayerEntity.class, TrackedDataHandlerRegistry.INTEGER);
     public static final TrackedData<Long> LIFE_REGAIN_TIME_MARKER = DataTracker.registerData(PlayerEntity.class, TrackedDataHandlerRegistry.LONG);
-
+    public static final TrackedData<Long> LIFE_REGAIN_REALTIME_MARKER = DataTracker.registerData(PlayerEntity.class, TrackedDataHandlerRegistry.LONG);
+    
     public static void load() {}
 }

--- a/src/main/resources/notsohardcore.accesswidener
+++ b/src/main/resources/notsohardcore.accesswidener
@@ -1,3 +1,4 @@
 accessWidener v2 named
 
 accessible method net/minecraft/server/network/ServerPlayerEntity$Respawn getDimension (Lnet/minecraft/server/network/ServerPlayerEntity$Respawn;)Lnet/minecraft/registry/RegistryKey;
+accessible method net/minecraft/client/gui/screen/Screen addDrawableChild (Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;

--- a/src/main/resources/notsohardcore.mixins.json
+++ b/src/main/resources/notsohardcore.mixins.json
@@ -1,14 +1,17 @@
 {
-	"required": true,
-	"package": "fr.factionbedrock.notsohardcore.mixin",
-	"compatibilityLevel": "JAVA_21",
-	"mixins": [
-		"PlayerDataTrackerMixin",
-		"PlayerNbtMixin",
-		"PlayerTickMixin",
-		"PlayerDeathMixin"
-	],
-	"injectors": {
-		"defaultRequire": 1
-	}
+  "required": true,
+  "package": "fr.factionbedrock.notsohardcore.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "PlayerDataTrackerMixin",
+    "PlayerNbtMixin",
+    "PlayerTickMixin",
+    "PlayerDeathMixin"
+  ],
+  "client": [
+    "DeathScreenMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
 }


### PR DESCRIPTION
This PR addresses multiple improvements:

**Respawn Fix** 

- Fixed issue where the respawn option did not appear even if the player had lives left.
- Added a respawn button so players can respawn properly.

**Time Tracking** 

Added an alternative time measuring function that uses real time since last life increase instead of in-game ticks.

This allows cooldowns (e.g., 1h) to progress even while not logged in.

**Config Commands (in-game)** 

- Switch between time modes (real time vs. in-game ticks).
- Set amount of lives.
- Set cooldown time.

Commands are the following:
- /nsh show
- /nsh realtime true
- /nsh maxLives 5
- /nsh cooldown seconds 1800
- /nsh cooldown ticks 72000



**Testing:**
Tested in singleplayer worlds (works as expected).
Not yet tested on servers, so behavior there may differ.

Notes:
This change solves my immediate needs in singleplayer, but I hope it also helps others who encounter the same problem. And also thanks for the mod. 